### PR TITLE
feat: sprint 5 basic status display foundation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-# Navigator UI Agent Package 
+# Navigator UI Agent Package

--- a/src/ui/content_card.py
+++ b/src/ui/content_card.py
@@ -1,0 +1,12 @@
+"""Content card component for Navigator UI."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_content_card(content: dict[str, str]) -> None:
+    """Display a simple content card with title, status, and summary."""
+    st.write(f"### {content.get('title', '')}")
+    st.write(f"Status: {content.get('status', '')}")
+    st.write(content.get("summary", ""))

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1,5 +1,7 @@
 import streamlit as st
 
+from .status_bar import render_status_bar
+
 SECTIONS = ["Goals", "Results", "Settings"]
 
 
@@ -12,6 +14,7 @@ def render_sidebar() -> str:
 def render_dashboard() -> None:
     """Render the dashboard based on selected navigation section."""
     section = render_sidebar()
+    render_status_bar()
     if section == "Goals":
         st.write("Goals View")
     elif section == "Results":

--- a/src/ui/status_bar.py
+++ b/src/ui/status_bar.py
@@ -1,0 +1,15 @@
+"""Static status bar component for Navigator UI."""
+
+import streamlit as st
+
+STATUSES = {
+    "Navigator-Ingest": "Idle",
+    "Strategy": "Idle",
+    "Pipeline": "Idle",
+}
+
+
+def render_status_bar() -> None:
+    """Display fixed agent status information."""
+    status_line = " | ".join(f"{name}: {state}" for name, state in STATUSES.items())
+    st.write(status_line)

--- a/tests/test_basic_status.py
+++ b/tests/test_basic_status.py
@@ -1,0 +1,88 @@
+# ruff: noqa: E402
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+
+def _stub_st(captured: dict) -> ModuleType:
+    st = ModuleType("streamlit")
+    st.sidebar = SimpleNamespace(
+        title=lambda text: captured.setdefault("title", text),
+        radio=lambda label, opts: captured.setdefault("options", opts) or opts[0],
+    )
+    st.set_page_config = lambda **k: None
+    st.write = lambda *a, **k: captured.setdefault("writes", []).append(
+        " ".join(str(x) for x in a)
+    )
+    return st
+
+
+sys.modules.setdefault("streamlit", _stub_st({}))
+
+import app
+from src.ui import dashboard, status_bar, content_card
+
+
+def test_render_status_bar(monkeypatch):
+    cap: dict[str, object] = {}
+    monkeypatch.setattr(status_bar, "st", _stub_st(cap))
+    status_bar.render_status_bar()
+    out = " ".join(cap["writes"]) if cap.get("writes") else ""
+    assert "Navigator-Ingest" in out and "Strategy" in out and "Pipeline" in out
+
+
+def test_render_content_card(monkeypatch):
+    cap: dict[str, object] = {}
+    monkeypatch.setattr(content_card, "st", _stub_st(cap))
+    content_card.render_content_card(
+        {"title": "Test", "status": "Idle", "summary": "All good"}
+    )
+    assert cap["writes"] == ["### Test", "Status: Idle", "All good"]
+
+
+def test_dashboard_status_bar(monkeypatch):
+    cap: dict[str, object] = {}
+    st = _stub_st(cap)
+    st.sidebar.radio = lambda _label, _opts: "Goals"
+    monkeypatch.setattr(dashboard, "st", st)
+    monkeypatch.setattr(status_bar, "st", st)
+    dashboard.render_dashboard()
+    assert "Navigator-Ingest" in cap["writes"][0]
+    assert cap["writes"][-1] == "Goals View"
+
+
+@pytest.mark.parametrize(
+    "section,exp",
+    [
+        ("Goals", "Goals View"),
+        ("Results", "Results View"),
+        ("Settings", "Settings View"),
+    ],
+)
+def test_dashboard_all(monkeypatch, section: str, exp: str):
+    cap: dict[str, object] = {}
+    st = _stub_st(cap)
+    st.sidebar.radio = lambda _label, _opts: section
+    st.write = lambda msg: cap.setdefault("writes", []).append(msg)
+    monkeypatch.setattr(dashboard, "st", st)
+    monkeypatch.setattr(status_bar, "st", st)
+    dashboard.render_dashboard()
+    assert cap["writes"][-1] == exp
+
+
+def test_app_main(monkeypatch):
+    cap: dict[str, object] = {}
+    st = _stub_st(cap)
+    st.sidebar.radio = lambda _label, opts: cap.setdefault("options", opts) or "Goals"
+    monkeypatch.setattr(app, "st", st)
+    monkeypatch.setattr(dashboard, "st", st)
+    monkeypatch.setattr(status_bar, "st", st)
+    app.main()
+    assert "Navigator-Ingest" in " ".join(cap["writes"])
+    assert cap["options"] == ["Goals", "Results", "Settings"]


### PR DESCRIPTION
## Summary
- add static status bar component
- add content card component
- show status bar in dashboard
- cover new features with `test_basic_status`

## Testing
- `pytest -k test_basic_status --cov=src --cov=app --cov-report=term-missing -q`
- `scripts/ci/check_loc_budget.sh 120`
- `ruff format --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6847a1cb996083278570def0e936737b