### PR TITLE
feat: sprint 6 content feed

### DIFF
--- a/src/ui/content_feed.py
+++ b/src/ui/content_feed.py
@@ -1,0 +1,42 @@
+"""Interactive content feed with filtering."""
+
+from __future__ import annotations
+from typing import Iterable
+from . import content_card, filters
+
+MOCK_CONTENT: list[dict[str, str]] = [
+    {
+        "title": f"Article {i}",
+        "source": f"Source {i % 3 + 1}",
+        "timestamp": f"2025-06-{i:02d}",
+        "status": "New" if i % 2 == 0 else "Reviewed",
+        "summary": "Lorem ipsum dolor sit amet.",
+    }
+    for i in range(1, 11)
+]
+
+
+def filter_content(
+    items: Iterable[dict[str, str]],
+    status: str | None = None,
+    source: str | None = None,
+) -> list[dict[str, str]]:
+    """Return items matching provided status and source."""
+    result = []
+    for item in items:
+        if status and status != "All" and item.get("status") != status:
+            continue
+        if source and source != "All" and item.get("source") != source:
+            continue
+        result.append(item)
+    return result
+
+
+def render_content_feed() -> None:
+    """Render content feed with filtering controls."""
+    statuses = sorted({c["status"] for c in MOCK_CONTENT})
+    sources = sorted({c["source"] for c in MOCK_CONTENT})
+    status_sel, source_sel = filters.render_filters(statuses, sources)
+    filtered = filter_content(MOCK_CONTENT, status_sel, source_sel)
+    for item in filtered:
+        content_card.render_content_card(item)

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
 from .status_bar import render_status_bar
+from .content_feed import render_content_feed
 
 SECTIONS = ["Goals", "Results", "Settings"]
 
@@ -16,6 +17,7 @@ def render_dashboard() -> None:
     section = render_sidebar()
     render_status_bar()
     if section == "Goals":
+        render_content_feed()
         st.write("Goals View")
     elif section == "Results":
         st.write("Results View")

--- a/src/ui/filters.py
+++ b/src/ui/filters.py
@@ -1,0 +1,12 @@
+"""Filtering controls for content feed."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_filters(statuses: list[str], sources: list[str]) -> tuple[str, str]:
+    """Return selected status and source options."""
+    status = st.sidebar.selectbox("Status", ["All"] + statuses)
+    source = st.sidebar.selectbox("Source", ["All"] + sources)
+    return status, source

--- a/tests/test_basic_status.py
+++ b/tests/test_basic_status.py
@@ -15,6 +15,7 @@ def _stub_st(captured: dict) -> ModuleType:
     st.sidebar = SimpleNamespace(
         title=lambda text: captured.setdefault("title", text),
         radio=lambda label, opts: captured.setdefault("options", opts) or opts[0],
+        selectbox=lambda label, opts: opts[0],
     )
     st.set_page_config = lambda **k: None
     st.write = lambda *a, **k: captured.setdefault("writes", []).append(

--- a/tests/test_content_feed.py
+++ b/tests/test_content_feed.py
@@ -1,0 +1,61 @@
+# ruff: noqa: E402
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# Utility to create a dummy streamlit replacement
+def _stub_st(captured: dict) -> ModuleType:
+    st = ModuleType("streamlit")
+    st.sidebar = SimpleNamespace(
+        selectbox=lambda _label, opts: opts[0],
+        radio=lambda _label, opts: opts[0],
+        title=lambda text: captured.setdefault("title", text),
+    )
+    st.write = lambda *a, **k: captured.setdefault("writes", []).append(
+        " ".join(str(x) for x in a)
+    )
+    st.set_page_config = lambda **k: None
+    return st
+
+
+from src.ui import content_feed, filters, content_card
+
+
+def test_mock_content_basic():
+    assert len(content_feed.MOCK_CONTENT) >= 10
+    first = content_feed.MOCK_CONTENT[0]
+    assert {"title", "source", "timestamp"} <= first.keys()
+
+
+def test_filter_content():
+    items = [
+        {"title": "t1", "status": "New", "source": "A"},
+        {"title": "t2", "status": "Done", "source": "B"},
+    ]
+    assert content_feed.filter_content(items, status="New") == [items[0]]
+    assert content_feed.filter_content(items, source="B") == [items[1]]
+    assert content_feed.filter_content(items, status="New", source="A") == [items[0]]
+
+
+def test_render_content_feed(monkeypatch):
+    cap: dict[str, object] = {}
+    st = _stub_st(cap)
+    first = content_feed.MOCK_CONTENT[0]
+    monkeypatch.setattr(filters, "st", st)
+    monkeypatch.setattr(
+        filters, "render_filters", lambda _s, _p: (first["status"], first["source"])
+    )
+    rendered: list[dict] = []
+    monkeypatch.setattr(
+        content_card, "render_content_card", lambda c: rendered.append(c)
+    )
+    content_feed.render_content_feed()
+    expected = content_feed.filter_content(
+        content_feed.MOCK_CONTENT, first["status"], first["source"]
+    )
+    assert rendered == expected

--- a/tests/test_ui_foundation.py
+++ b/tests/test_ui_foundation.py
@@ -17,6 +17,7 @@ def _create_stub_streamlit(captured: dict) -> ModuleType:
     st.sidebar = SimpleNamespace(
         title=lambda text: captured.setdefault("title", text),
         radio=radio,
+        selectbox=lambda label, opts: opts[0],
     )
     st.set_page_config = lambda **kwargs: None
     st.write = lambda *args, **kwargs: None


### PR DESCRIPTION
## Summary
- implement interactive content feed with filters
- integrate feed into dashboard Goals section
- add filter controls component
- cover new functionality with tests
- clean up tests to respect LOC budget

## Testing
- `ruff format --check`
- `ruff check --exit-zero`
- `pytest -q`
- `scripts/ci/check_new_deps.sh`
- `scripts/ci/check_loc_budget.sh 120`


------
https://chatgpt.com/codex/tasks/task_e_6847a468dda88327be3bcde26af8794a